### PR TITLE
Add versioning support and display version in UI

### DIFF
--- a/BitPantry.Tabs.Web/AppVersionHelper.cs
+++ b/BitPantry.Tabs.Web/AppVersionHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+
+namespace BitPantry.Tabs.Web
+{
+    public static class AppVersionHelper
+    {
+        public static string GetInformationalVersion() =>
+            Assembly
+                .GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion ?? "unknown";
+    }
+}

--- a/BitPantry.Tabs.Web/BitPantry.Tabs.Web.csproj
+++ b/BitPantry.Tabs.Web/BitPantry.Tabs.Web.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.4" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
     <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.3.8" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Seq.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/BitPantry.Tabs.Web/TabsWebBootstrap.cs
+++ b/BitPantry.Tabs.Web/TabsWebBootstrap.cs
@@ -60,7 +60,11 @@ namespace BitPantry.Tabs.Web
 
             // build the application
 
-            return builder.Build().ConfigureTabsWebApplication(settings);
+            var app = builder.Build().ConfigureTabsWebApplication(settings);
+
+            app.MapGet("/version", () => { return Results.Ok(new { version = AppVersionHelper.GetInformationalVersion() }); });
+
+            return app;
         }
 
         private static WebApplication ConfigureTabsWebApplication(this WebApplication app, WebAppSettings settings)

--- a/BitPantry.Tabs.Web/Views/Shared/_Layout.cshtml
+++ b/BitPantry.Tabs.Web/Views/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=help" />
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
 
     <style>
         .material-symbols-outlined {
@@ -75,12 +75,16 @@
         </nav>
     </header>
 
-
-    <div class="container">
+    <div class="container flex-grow-1">
         <main role="main" class="pb-3">
             @RenderBody()
         </main>
     </div>
+
+    <footer class="text-center py-3 mt-auto" style="color: #b0b0b0;">
+        @AppVersionHelper.GetInformationalVersion()
+    </footer>
+
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
@@ -95,5 +99,6 @@
     <div class="d-none d-md-block d-lg-none" style="background: #ffc108; color: #fff; padding: 5px; text-align: center;">MD</div>
     <div class="d-none d-sm-block d-md-none" style="background: #18a2b8; color: #fff; padding: 5px; text-align: center;">SM</div>
     <div class="d-block d-sm-none" style="background: #dc3545; color: #fff; padding: 5px; text-align: center;">XS</div>  *@
+
 </body>
 </html>

--- a/BitPantry.Tabs.Web/version.json
+++ b/BitPantry.Tabs.Web/version.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0",
+  "assemblyVersion": "1.0",
+  "fileVersion": "1.0.0.0",
+  "publicRelease": true,
+  "gitCommitIdShort": true
+}


### PR DESCRIPTION
Added `Nerdbank.GitVersioning` package to `BitPantry.Tabs.Web.csproj` for version management. Modified `TabsWebBootstrap.cs` to include a `/version` endpoint that returns the application's informational version. Updated `_Layout.cshtml` to add a footer displaying the version, and ensure the main content container grows to fill available space. Introduced `AppVersionHelper` class to retrieve the version using reflection. Added `version.json` to define versioning information.