### PR TITLE
Remove screenshot capture from queue reorder test

### DIFF
--- a/BitPantry.Tabs.Test.Playwright/Common/CollectionTests.cs
+++ b/BitPantry.Tabs.Test.Playwright/Common/CollectionTests.cs
@@ -182,10 +182,6 @@ namespace BitPantry.Tabs.Test.Playwright.Common
 
                 await Page.GetByTestId("collection.tabQueue").ClickAsync();
 
-                await Page.ScreenshotAsync(new PageScreenshotOptions
-                {
-                    Path = "c:\\src\\reorder.png"
-                });
 
                 await reorderAction(cards[0], cards[1]);
                 await reorderAction(cards[0], cards[3]);


### PR DESCRIPTION
## Summary
- delete screenshot usage from `QueueTabReorderCardList_CardsReordered` test

## Testing
- `dotnet test` *(fails: `dotnet` not found)*