### PR TITLE
Fix typo 'occurred'

### DIFF
--- a/BitPantry.Tabs.Infrastructure/Settings/AppSettingsBase.cs
+++ b/BitPantry.Tabs.Infrastructure/Settings/AppSettingsBase.cs
@@ -61,7 +61,7 @@ namespace BitPantry.Tabs.Infrastructure.Settings
         private AppSettingsException CreateAppConfigurationException(string key, Exception innerException)
         {
             return new AppSettingsException(
-                $"An application setting error occured while getting the value for key \"{FormatKey(key)}\"",
+                $"An application setting error occurred while getting the value for key \"{FormatKey(key)}\"",
                 innerException);
         }
     }

--- a/BitPantry.Tabs.Shell/Program.cs
+++ b/BitPantry.Tabs.Shell/Program.cs
@@ -64,7 +64,7 @@ namespace BitPantry.Tabs.Shell
                 catch (Exception ex)
                 {
                     System.Console.ForegroundColor = ConsoleColor.Red;
-                    System.Console.WriteLine($"An unhandled exception occured :: {ex.Message}");
+                    System.Console.WriteLine($"An unhandled exception occurred :: {ex.Message}");
                     System.Console.ResetColor();
                 }
             } while (true);

--- a/BitPantry.Tabs.Web/SessionStateBase.cs
+++ b/BitPantry.Tabs.Web/SessionStateBase.cs
@@ -96,7 +96,7 @@ namespace BitPantry.Tabs.Web
         private SessionStateException CreateSessionStateException(string key, Exception innerException)
         {
             return new SessionStateException(
-                $"An application setting error occured while getting the value for key \"{FormatKey(key)}\"",
+                $"An application setting error occurred while getting the value for key \"{FormatKey(key)}\"",
                 innerException);
         }
 

--- a/BitPantry.Tabs.Web/Views/Shared/Error.cshtml
+++ b/BitPantry.Tabs.Web/Views/Shared/Error.cshtml
@@ -1,6 +1,6 @@
 ﻿
 <p class="display-6 mt-4">
-    An error occured
+    An error occurred
 </p>
 
 <p mt-3>


### PR DESCRIPTION
## Summary
- fix typo `occured` -> `occurred`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*