### PR TITLE
Fix unit tests

### DIFF
--- a/BitPantry.Tabs.Test.Application/Components/ReviewPathDtoTests.cs
+++ b/BitPantry.Tabs.Test.Application/Components/ReviewPathDtoTests.cs
@@ -1,0 +1,22 @@
+using BitPantry.Tabs.Application.DTO;
+using System.Collections.Generic;
+using BitPantry.Tabs.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.Components;
+
+public class ReviewPathDtoTests
+{
+    [Fact]
+    public void CardsToReviewCount_SumsValues()
+    {
+        var dto = new ReviewPathDto(1, new Dictionary<Tab, int>
+        {
+            {Tab.Daily, 1},
+            {Tab.Odd, 2}
+        });
+
+        dto.CardsToReviewCount.Should().Be(3);
+    }
+}

--- a/BitPantry.Tabs.Test.Application/Components/TabExtensionsTests.cs
+++ b/BitPantry.Tabs.Test.Application/Components/TabExtensionsTests.cs
@@ -1,0 +1,20 @@
+using BitPantry.Tabs.Application;
+using System;
+using BitPantry.Tabs.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.Components;
+
+public class TabExtensionsTests
+{
+    [Theory]
+    [InlineData(Tab.Queue, DayOfWeek.Monday, Tab.Daily)]
+    [InlineData(Tab.Daily, DayOfWeek.Tuesday, Tab.Even)]
+    [InlineData(Tab.Odd, DayOfWeek.Sunday, Tab.Sunday)]
+    public void GetNextReviewTab_ReturnsExpected(Tab start, DayOfWeek day, Tab expected)
+    {
+        var result = start.GetNextReviewTab(new DateTime(2024, 1, (int)day + 1));
+        result.Should().Be(expected);
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/BibleServiceTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/BibleServiceTests.cs
@@ -1,0 +1,57 @@
+using BitPantry.Tabs.Application.DTO;
+using BitPantry.Tabs.Application.Parsers.BibleData;
+using BitPantry.Tabs.Application.Service;
+using BitPantry.Tabs.Data.Entity;
+using BitPantry.Tabs.Test.Application.Fixtures;
+using BitPantry.Tabs.Test;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+[Collection("env")]
+public class BibleServiceTests
+{
+    private readonly ApplicationEnvironment _env;
+
+    public BibleServiceTests(AppEnvironmentFixture fixture)
+    {
+        _env = fixture.Environment;
+    }
+
+    [Fact]
+    public async Task InstallStream_BibleInstalled()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<BibleService>();
+
+        var id = await svc.Install(new MemoryStream(TestResources.Translations.ESV), CancellationToken.None);
+
+        id.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GetBiblePassage_ReturnsVerses()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<BibleService>();
+
+        var bibleId = await svc.Install(new MemoryStream(TestResources.Translations.MSG), CancellationToken.None);
+        var resp = await svc.GetBiblePassage(bibleId, "jn 3:16", CancellationToken.None);
+
+        resp.Passage.Should().NotBeNull();
+        resp.Passage.Verses.Should().HaveCountGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task InstallBadXml_Throws()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<BibleService>();
+
+        var act = async () => await svc.Install(new MemoryStream(TestResources.Translations.ESV_badClassification), CancellationToken.None);
+
+        await act.Should().ThrowAsync<BibleDataParsingException>();
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/CacheServiceTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/CacheServiceTests.cs
@@ -1,0 +1,43 @@
+using BitPantry.Tabs.Infrastructure.Caching;
+using System.Collections.Generic;
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+public class CacheServiceTests
+{
+    private class FakeCache : ICache
+    {
+        private readonly Dictionary<string, object> _dict = new();
+        public T Get<T>(string key) => (T)_dict[key];
+        public bool TryGetValue<T>(string key, out T outVal)
+        {
+            if (_dict.TryGetValue(key, out var obj))
+            {
+                outVal = (T)obj;
+                return true;
+            }
+            outVal = default!;
+            return false;
+        }
+        public void Set(string key, object obj, TimeSpan slidingExpiration)
+        {
+            _dict[key] = obj;
+        }
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_CachesValue()
+    {
+        var cache = new FakeCache();
+        var svc = new CacheService(cache);
+        int callCount = 0;
+        var result1 = await svc.GetOrCreateAsync("k", async () => { callCount++; return 5; });
+        var result2 = await svc.GetOrCreateAsync("k", async () => { callCount++; return 6; });
+        result1.Should().Be(5);
+        result2.Should().Be(5);
+        callCount.Should().Be(1);
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/CardServiceErrorTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/CardServiceErrorTests.cs
@@ -1,0 +1,35 @@
+using BitPantry.Tabs.Application.Service;
+using BitPantry.Tabs.Common;
+using BitPantry.Tabs.Test.Application.Fixtures;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+[Collection("env")]
+public class CardServiceErrorTests
+{
+    private readonly ApplicationEnvironment _env;
+    private readonly long _bibleId;
+
+    public CardServiceErrorTests(AppEnvironmentFixture fixture)
+    {
+        _env = fixture.Environment;
+        _bibleId = fixture.BibleId;
+    }
+
+    [Fact]
+    public async Task StartQueueCard_NotQueue_Throws()
+    {
+        var userId = await _env.CreateUser();
+        using var scope = _env.ServiceProvider.CreateScope();
+        var wfSvc = scope.ServiceProvider.GetRequiredService<IWorkflowService>();
+        var cardSvc = scope.ServiceProvider.GetRequiredService<CardService>();
+        var card = await cardSvc.CreateCard(userId, _bibleId, "gen 1:1", Tab.Daily, CancellationToken.None);
+
+        var act = async () => await wfSvc.StartQueueCard(card.Card.Id, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/DataProtectionServiceTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/DataProtectionServiceTests.cs
@@ -1,0 +1,49 @@
+using System.Xml.Linq;
+using BitPantry.Tabs.Application.Service;
+using BitPantry.Tabs.Data.Entity;
+using BitPantry.Tabs.Test.Application.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+[Collection("env")]
+public class DataProtectionServiceTests
+{
+    private readonly ApplicationEnvironment _env;
+
+    public DataProtectionServiceTests(AppEnvironmentFixture fixture)
+    {
+        _env = fixture.Environment;
+    }
+
+    [Fact]
+    public async Task StoreAndReadKeys_KeysPersisted()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var dbCtx = scope.ServiceProvider.GetRequiredService<EntityDataContext>();
+        var svc = new DataProtectionService(dbCtx);
+
+        await svc.StoreDataProtectionKeys("<key>1</key>", DateTime.UtcNow);
+        await svc.StoreDataProtectionKeys("<key>2</key>", DateTime.UtcNow);
+
+        var keys = await svc.ReadDataProtectionKeys();
+
+        keys.Should().HaveCount(2);
+        keys.Select(k => k.ToString()).Should().Contain(new[]{"<key>1</key>", "<key>2</key>"});
+    }
+
+    [Fact]
+    public async Task ReadKeys_NoKeys_EmptyCollection()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var dbCtx = scope.ServiceProvider.GetRequiredService<EntityDataContext>();
+        var svc = new DataProtectionService(dbCtx);
+
+        var keys = await svc.ReadDataProtectionKeys();
+
+        keys.Should().BeEmpty();
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/QueryableExtensionsTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/QueryableExtensionsTests.cs
@@ -1,0 +1,50 @@
+using BitPantry.Tabs.Infrastructure.Caching;
+using System;
+using System.Collections.Generic;
+using BitPantry.Tabs.Data.Entity;
+using BitPantry.Tabs.Test.Application.Fixtures;
+using BitPantry.Tabs.Test.Application;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using FluentAssertions;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+[Collection("env")]
+public class QueryableExtensionsTests
+{
+    private readonly ApplicationEnvironment _env;
+
+    public QueryableExtensionsTests(AppEnvironmentFixture fixture)
+    {
+        _env = fixture.Environment;
+    }
+
+    [Fact]
+    public async Task WithCaching_NotNoTracking_Throws()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EntityDataContext>();
+
+        db.Users.Add(new User { EmailAddress = "test@test.com" });
+        await db.SaveChangesAsync();
+
+        var query = db.Users;
+        var svc = new CacheService(new DummyCache());
+        Action act = () => query.WithCaching(svc);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private class DummyCache : ICache
+    {
+        private readonly Dictionary<string, object> _data = new();
+        public T Get<T>(string key) => (T)_data[key];
+        public bool TryGetValue<T>(string key, out T outVal)
+        {
+            if(_data.TryGetValue(key, out var obj)) { outVal = (T)obj; return true; }
+            outVal = default!; return false;
+        }
+        public void Set(string key, object obj, TimeSpan slidingExpiration) => _data[key] = obj;
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/TabsServiceTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/TabsServiceTests.cs
@@ -1,0 +1,57 @@
+using BitPantry.Tabs.Application.Service;
+using BitPantry.Tabs.Common;
+using BitPantry.Tabs.Data.Entity;
+using BitPantry.Tabs.Test.Application.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+[Collection("env")]
+public class TabsServiceTests
+{
+    private readonly ApplicationEnvironment _env;
+    private readonly long _bibleId;
+
+    public TabsServiceTests(AppEnvironmentFixture fixture)
+    {
+        _env = fixture.Environment;
+        _bibleId = fixture.BibleId;
+    }
+
+    [Fact]
+    public async Task GetCardsForTab_SingleCard_LoadsVerses()
+    {
+        var userId = await _env.CreateUser();
+        using var scope = _env.ServiceProvider.CreateScope();
+        var cardSvc = scope.ServiceProvider.GetRequiredService<CardService>();
+        var tabsSvc = new TabsService(scope.ServiceProvider.GetRequiredService<EntityDataContext>());
+
+        await cardSvc.CreateCard(userId, _bibleId, "gen 1:1", Tab.Daily, CancellationToken.None);
+
+        var cards = await tabsSvc.GetCardsForTab(userId, Tab.Daily, CancellationToken.None);
+        cards.Should().HaveCount(1);
+        cards[0].Passage.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetCardCountByTab_ReturnsCounts()
+    {
+        var userId = await _env.CreateUser();
+        using var scope = _env.ServiceProvider.CreateScope();
+        var cardSvc = scope.ServiceProvider.GetRequiredService<CardService>();
+        var tabsSvc = new TabsService(scope.ServiceProvider.GetRequiredService<EntityDataContext>());
+
+        await cardSvc.CreateCard(userId, _bibleId, "gen 1:1", Tab.Daily, CancellationToken.None);
+        await cardSvc.CreateCard(userId, _bibleId, "gen 1:2", Tab.Queue, CancellationToken.None);
+
+        var counts = await tabsSvc.GetCardCountByTab(userId, CancellationToken.None);
+
+        counts.Should().ContainKey(Tab.Daily);
+        counts.Should().ContainKey(Tab.Queue);
+        counts[Tab.Daily].Should().Be(1);
+        counts[Tab.Queue].Should().Be(1);
+    }
+}

--- a/BitPantry.Tabs.Test.Application/ServiceTests/UserServiceTests.cs
+++ b/BitPantry.Tabs.Test.Application/ServiceTests/UserServiceTests.cs
@@ -1,0 +1,52 @@
+using BitPantry.Tabs.Application.Service;
+using BitPantry.Tabs.Data.Entity;
+using BitPantry.Tabs.Test.Application.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BitPantry.Tabs.Test.Application.ServiceTests;
+
+[Collection("env")]
+public class UserServiceTests
+{
+    private readonly ApplicationEnvironment _env;
+
+    public UserServiceTests(AppEnvironmentFixture fixture)
+    {
+        _env = fixture.Environment;
+    }
+
+    [Fact]
+    public async Task GetUser_Nonexistent_ReturnsNull()
+    {
+        using var scope = _env.ServiceProvider.CreateScope();
+        var svc = new UserService(scope.ServiceProvider.GetRequiredService<EntityDataContext>());
+
+        var user = await svc.GetUser(9999);
+
+        user.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetUserByCliKey_ReturnsUser()
+    {
+        long userId;
+        using(var scope = _env.ServiceProvider.CreateScope())
+        {
+            var dbCtx = scope.ServiceProvider.GetRequiredService<EntityDataContext>();
+            var user = new User { EmailAddress = "cli@test.com", WorkflowType = Common.WorkflowType.Basic, CliApiKey = "abc" };
+            dbCtx.Users.Add(user);
+            await dbCtx.SaveChangesAsync();
+            userId = user.Id;
+        }
+        using(var scope = _env.ServiceProvider.CreateScope())
+        {
+            var svc = new UserService(scope.ServiceProvider.GetRequiredService<EntityDataContext>());
+            var dto = await svc.GetUser("abc");
+            dto.Should().NotBeNull();
+            dto.Id.Should().Be(userId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix TabsServiceTests to check Passage instead of Verses
- use AppEnvironmentFixture in QueryableExtensionsTests instead of InMemoryDatabase

## Testing
- `dotnet test` *(fails: dotnet not found)*